### PR TITLE
Update README with instructions to run the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 These guides accompany the chapters of [ml4a.github.io](http://ml4a.github.io), providing a series of pre-baked code samples, IPython notebooks, and markdown-based tutorials guiding the interested reader in how to practically work with some of the algorithms described by ml4a.
 
 The homepage for these is [here](http://ml4a.github.io/guides), which contains an overview of the included guides and tutorials, as well as some additional (in-progress) materials to help you get setup.
+
+## Running the container
+
+You can easily run these guides using Docker. With docker installed, run the following from inside the repo:
+
+```bash
+docker build -t genekogan/ml4a-guides .
+```
+
+Once the container has successfully built, you can launch it with:
+
+```bash
+./run.sh
+```
+
+A Jupyter Notebook should now be running inside of the docker container, accessible from your host machine at `http://localhost:8888`. From Jupyter browser page, navigate to wherever you cloned `ml4a-guides` to run the notebooks. 
+
+If that port is already occupied, you may recieve an error from the `run.sh` script. You can easily switch the port published to the docker instance like so:
+
+```bash
+JUPYTER_PORT=1337 ./run.sh # visit at http://localhost:1337 instead
+```
+

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 CONTAINER="ml4a-guides"
 IMAGE="genekogan/$CONTAINER"
 IMAGE_FILE="$CONTAINER.tar"
-JUPYTER_PORT="8888"
+JUPYTER_PORT=${JUPYTER_PORT:-8888}
 
 if ! ( docker images | grep "$IMAGE" &>/dev/null ) ; then
 	if [ -e $IMAGE_FILE ]; then


### PR DESCRIPTION
It seems to me that without a `genekogan/ml4a-guides` image publicly accessible on a docker image repository (like docker hub), the image has to be built using the Dockerfile. I've provided instructions for doing so in the README. 