### PR TITLE
Enable pasting of images with alpha channel for image t-SNE

### DIFF
--- a/notebooks/image-tsne.ipynb
+++ b/notebooks/image-tsne.ipynb
@@ -234,12 +234,12 @@
     "height = 3000\n",
     "max_dim = 100\n",
     "\n",
-    "full_image = Image.new('RGB', (width, height))\n",
+    "full_image = Image.new('RGBA', (width, height))\n",
     "for img, x, y in tqdm(zip(images, tx, ty)):\n",
     "    tile = Image.open(img)\n",
     "    rs = max(1, tile.width/max_dim, tile.height/max_dim)\n",
     "    tile = tile.resize((int(tile.width/rs), int(tile.height/rs)), Image.ANTIALIAS)\n",
-    "    full_image.paste(tile, (int((width-max_dim)*x), int((height-max_dim)*y)))\n",
+    "    full_image.paste(tile, (int((width-max_dim)*x), int((height-max_dim)*y)), mask=tile.convert('RGBA'))\n",
     "\n",
     "matplotlib.pyplot.figure(figsize = (16,12))\n",
     "imshow(full_image)"
@@ -260,7 +260,7 @@
    },
    "outputs": [],
    "source": [
-    "full_image.save(\"../assets/example-tSNE-animals1k.jpg\")"
+    "full_image.save(\"../assets/example-tSNE-animals1k.png\")\n"
    ]
   },
   {


### PR DESCRIPTION
The t-SNE visualisation currently doesn't support datasets with alpha channels. Made a few minor modifications to allowing stacking and saving of transparent PNGs via Pillow. Thought it might be useful for other people with datasets with transparent images :)

Changes:
- pass `RGBA` when instantiating new image
- Add a `mask` param to enable transparent images to be stacked
- Save output as `.png` format for alpha channel