### PR TITLE
Reordered pillow install and removed anaconda flag. Building now works.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN pip install --ignore-installed --upgrade https://storage.googleapis.com/tens
 
 RUN conda install -y scikit-learn
 
-RUN conda install -c anaconda -y pillow=3.4.1
-
 RUN conda install -c conda-forge librosa
 
 RUN conda install -c mutirri -y blessings=1.6
@@ -19,3 +17,4 @@ RUN conda install -c conda-forge tqdm=4.14.0
 
 RUN pip install python-igraph
 
+RUN conda install -y pillow=3.4.1


### PR DESCRIPTION
Prior to this, I would get the following error:

```
$ docker build -t ml4a .
Sending build context to Docker daemon  83.56MB
Step 1/9 : FROM ermaker/keras
 ---> 0361004a5be6
Step 2/9 : RUN conda install -y     jupyter     matplotlib     seaborn
 ---> Using cache
 ---> 3106479ca75d
Step 3/9 : RUN pip install --ignore-installed --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.2.0-cp27-none-linux_x86_64.whl
 ---> Using cache
 ---> 2f6b2a118244
Step 4/9 : RUN conda install -y scikit-learn
 ---> Using cache
 ---> ed874217c627
Step 5/9 : RUN conda install -c anaconda -y pillow=3.4.1
 ---> Running in 8da3bcfc92d4
Solving environment: ...working... done
libtiff 4.0.6: ########## | 100% 
pixman 0.34.0: ########## | 100% 
libxml2 2.9.4: ########## | 100% 
pillow 3.4.1: ########## | 100% 
cairo 1.14.8: ########## | 100% 
openssl 1.0.2n: #######5   |  75% 
jbig 2.1: ########## | 100% 
libiconv 1.14: ########## | 100% 
matplotlib 2.0.2: ########## | 100% 
icu 54.1: ########## | 100% 
qt 5.6.2: ########## | 100% 
jpeg 8d: ########## | 100% 
pycairo 1.13.3: ########## | 100% 
fontconfig 2.12.1: ########## | 100% 
certifi 2018.1.18: #######5   |  75% 
freetype 2.5.5: ########## | 100% 
ca-certificates 2017.08.26: #######5   |  75% 
libgcc 7.2.0: ########## | 100% 

IOError(21, 'Is a directory')
IOError(21, 'Is a directory')
IOError(21, 'Is a directory')



## Package Plan ##

  environment location: /root/miniconda2

  added / updated specs: 
    - pillow=3.4.1


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    libtiff-4.0.6              |                2         1.5 MB  anaconda
    pixman-0.34.0              |       hceecf20_3         598 KB  anaconda
    libxml2-2.9.4              |                0         3.7 MB  anaconda
    pillow-3.4.1               |           py27_0         852 KB  anaconda
    cairo-1.14.8               |                0         609 KB  anaconda
    openssl-1.0.2n             |       hb7f436b_0         3.4 MB  anaconda
    jbig-2.1                   |       hdba287a_0          41 KB  anaconda
    libiconv-1.14              |                0         2.0 MB  anaconda
    matplotlib-2.0.2           |      np113py27_0        10.6 MB  anaconda
    icu-54.1                   |                0        11.3 MB  anaconda
    qt-5.6.2                   |                2        44.2 MB  anaconda
    jpeg-8d                    |                2         806 KB  anaconda
    pycairo-1.13.3             |   py27hea6d626_0          54 KB  anaconda
    fontconfig-2.12.1          |                3         429 KB  anaconda
    certifi-2018.1.18          |           py27_0         143 KB  anaconda
    freetype-2.5.5             |                2         2.5 MB  anaconda
    ca-certificates-2017.08.26 |       h1d4fec5_0         263 KB  anaconda
    libgcc-7.2.0               |       h69d50b8_2         304 KB  anaconda
    ------------------------------------------------------------
                                           Total:        83.2 MB

The following NEW packages will be INSTALLED:

    cairo:           1.14.8-0              anaconda
    jbig:            2.1-hdba287a_0        anaconda
    libgcc:          7.2.0-h69d50b8_2      anaconda
    libiconv:        1.14-0                anaconda
    libtiff:         4.0.6-2               anaconda
    pillow:          3.4.1-py27_0          anaconda
    pixman:          0.34.0-hceecf20_3     anaconda
    pycairo:         1.13.3-py27hea6d626_0 anaconda

The following packages will be UPDATED:

    ca-certificates: 2017.08.26-h1d4fec5_0          --> 2017.08.26-h1d4fec5_0 anaconda
    certifi:         2018.1.18-py27_0               --> 2018.1.18-py27_0      anaconda
    openssl:         1.0.2n-hb7f436b_0              --> 1.0.2n-hb7f436b_0     anaconda

The following packages will be DOWNGRADED:

    fontconfig:      2.12.4-h88586e7_1              --> 2.12.1-3              anaconda
    freetype:        2.8-hab7d2ae_1                 --> 2.5.5-2               anaconda
    icu:             58.2-h9c2bf20_1                --> 54.1-0                anaconda
    jpeg:            9b-h024ee3a_2                  --> 8d-2                  anaconda
    libxml2:         2.9.7-h26e45fe_0               --> 2.9.4-0               anaconda
    matplotlib:      2.1.2-py27h0e671d2_0           --> 2.0.2-np113py27_0     anaconda
    qt:              5.6.2-h974d657_12              --> 5.6.2-2               anaconda


Downloading and Extracting Packages
The command '/bin/sh -c conda install -c anaconda -y pillow=3.4.1' returned a non-zero code: 1
```