### PR TITLE
3 minor changes.

### DIFF
--- a/notebooks/audio-tsne.ipynb
+++ b/notebooks/audio-tsne.ipynb
@@ -20,9 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -50,9 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -95,10 +91,12 @@
     "def get_features(y, sr):\n",
     "    y = y[0:sr]  # analyze just first second\n",
     "    S = librosa.feature.melspectrogram(y, sr=sr, n_mels=128)\n",
-    "    log_S = librosa.logamplitude(S, ref_power=np.max)\n",
+    "    log_S = librosa.amplitude_to_db(S, ref=np.max)\n",
     "    mfcc = librosa.feature.mfcc(S=log_S, n_mfcc=13)\n",
     "    delta_mfcc = librosa.feature.delta(mfcc)\n",
     "    delta2_mfcc = librosa.feature.delta(mfcc, order=2)\n",
+    "    # mode='nearest' can be added to avoid problems such as;\n",
+    "    #ParameterError: when mode='interp', width=9 cannot exceed data.shape[axis]=n\n",
     "    feature_vector = np.concatenate((np.mean(mfcc,1), np.mean(delta_mfcc,1), np.mean(delta2_mfcc,1)))\n",
     "    feature_vector = (feature_vector-np.mean(feature_vector))/np.std(feature_vector)\n",
     "    return feature_vector"
@@ -114,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -280,9 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -332,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -370,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -390,7 +380,7 @@
     "\n",
     "data = [{\"path\":os.path.abspath(f), \"point\":[x, y]} for f, x, y in zip(sound_paths, x_norm, y_norm)]\n",
     "with open(tsne_path, 'w') as outfile:\n",
-    "    json.dump(data, outfile)\n",
+    "    json.dump(data, outfile, cls=MyEncoder)\n",
     "\n",
     "print(\"saved %s to disk!\" % tsne_path)"
    ]
@@ -407,9 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "source_audio = '/Users/gene/Downloads/bohemianrhapsody.mp3'"
@@ -425,9 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hop_length = 512\n",
@@ -447,9 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -492,9 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -544,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -605,9 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -633,27 +611,49 @@
    "source": [
     "Not surprisingly, audio clips which appear close to each other (and therefore have a similar color) also cluster together in the t-SNE. Two clips that are right next to each other probably have similar sound content and therefore similar feature vectors. But we also see different sections (e.g. teal and orange) appearing clustered together as well. This suggests those two sections may have similar audio content as well."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#“TypeError: Object of type 'float32' is not JSON serializable” \n",
+    "#error during the creation of the .json file can be resolved \n",
+    "#by writing a serializer and adding “cls=MyEncoder” parameter to json.dump.\n",
+    "\n",
+    "class MyEncoder(json.JSONEncoder):\n",
+    "    def default(self, obj):\n",
+    "        if isinstance(obj, np.integer):\n",
+    "            return int(obj)\n",
+    "        elif isinstance(obj, np.floating):\n",
+    "            return float(obj)\n",
+    "        elif isinstance(obj, np.ndarray):\n",
+    "            return obj.tolist()\n",
+    "        else:\n",
+    "            return super(MyEncoder, self).default(obj)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Hey Gene, thanks for the great code. Just tried this and had to change a few things to finish it. Not sure why these errors occurred but thought maybe I could take note for future references. 

Best wishes!

librosa.core.logamplitude has been removed in v0.6  and has now been replaced by amplitude_to_db. Also the “ref_power” parameter is replaced by “ref”

log_S = librosa.amplitude_to_db(S, ref=np.max)

“TypeError: Object of type 'float32' is not JSON serializable” error during the creation of the .json file can be resolved by writing a serializer and adding “cls=MyEncoder” parameter to json.dump.

json.dump(data, outfile, cls=MyEncoder) 

class MyEncoder(json.JSONEncoder):
    def default(self, obj):
        if isinstance(obj, np.integer):
            return int(obj)
        elif isinstance(obj, np.floating):
            return float(obj)
        elif isinstance(obj, np.ndarray):
            return obj.tolist()
        else:
            return super(MyEncoder, self).default(obj)


ParameterError: when mode='interp', width=9 cannot exceed data.shape[axis]=n

mode='nearest' can be added to alter the default ‘interp’ to avoid this. This seem to occur in longer audio files.