### PR TITLE
resize: Use BICUBIC sampling instead of nearest

### DIFF
--- a/utils/processing.py
+++ b/utils/processing.py
@@ -154,7 +154,7 @@ def crop_rot_resize(img, frac, w2, h2, ang, stretch, centered):
     x_crop, y_crop = (w1 - w1_crop - 1) * xr, (h1 - h1_crop - 1) * yr
     h1_crop, w1_crop, y_crop, x_crop = int(h1_crop), int(w1_crop), int(y_crop), int(x_crop)
     img_crop = img.crop((x_crop, y_crop, x_crop+w1_crop, y_crop+h1_crop))
-    img_resize = img_crop.resize((w2, h2))
+    img_resize = img_crop.resize((w2, h2), resample=Image.BICUBIC)
     
     return img_resize
 


### PR DESCRIPTION
@genekogan 

from the workshop today.

Before:
![image](https://user-images.githubusercontent.com/1776635/49333750-65fe6000-f592-11e8-9480-3a5eb2a7929e.png)


After:
![f00000_disturbing-muses-1918-3](https://user-images.githubusercontent.com/1776635/49333748-5848da80-f592-11e8-86c3-10a2de74754f.png)


