### PR TITLE
Download archived version of Caltech dataset

### DIFF
--- a/data/download.sh
+++ b/data/download.sh
@@ -1,7 +1,8 @@
 
 # for most image processing notebooks, get 101_Object_Categories
 echo "Downloading 101_Object_Categories for image notebooks"
-curl -L -o 101_ObjectCategories.tar.gz --progress-bar http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz
+# curl -L -o 101_ObjectCategories.tar.gz --progress-bar http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz
+curl -L -o 101_ObjectCategories.tar.gz --progress-bar https://web.archive.org/web/20200509103714id_/http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz
 tar -xzf 101_ObjectCategories.tar.gz
 rm 101_ObjectCategories.tar.gz
 


### PR DESCRIPTION
The Caltech 101 dataset at http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz is not currently available, so I changed the URL to an archived version on archive.org